### PR TITLE
Fixed minimum OID length (allow 2 arcs instead of 3)

### DIFF
--- a/Asn1Parser/Universal/Asn1ObjectIdentifier.cs
+++ b/Asn1Parser/Universal/Asn1ObjectIdentifier.cs
@@ -135,11 +135,11 @@ public sealed class Asn1ObjectIdentifier : Asn1Universal {
     }
     static Boolean validateOidString(String oid, out List<BigInteger> tokens) {
         String[] strTokens = oid.Split('.');
-        if (strTokens.Length < 3) {
-            tokens = null;
+        if (strTokens.Length < 2) {
+            tokens = [];
             return false;
         }
-        tokens = new List<BigInteger>();
+        tokens = [];
         for (Int32 index = 0; index < strTokens.Length; index++) {
             try {
                 var value = BigInteger.Parse(strTokens[index]);
@@ -148,7 +148,7 @@ public sealed class Asn1ObjectIdentifier : Asn1Universal {
                 }
                 tokens.Add(value);
             } catch {
-                tokens = null;
+                tokens = [];
                 return false;
             }
         }

--- a/tests/Asn1Parser.Tests/Asn1OidTests.cs
+++ b/tests/Asn1Parser.Tests/Asn1OidTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SysadminsLV.Asn1Parser.Universal;
+
+namespace Asn1Parser.Tests;
+
+[TestClass]
+public class Asn1OidTests {
+    [TestMethod, Description("Test if at least two arcs are encoded.")]
+    public void TestMinStringLengthEncode() {
+        var oid = new Asn1ObjectIdentifier("0.0");
+        Assert.AreEqual("0.0", oid.Value.Value);
+        String encodedB64 = Convert.ToBase64String(oid.GetRawData());
+        Assert.AreEqual("BgEA", encodedB64);
+    }
+    [TestMethod, Description("Test if at least two arcs are required.")]
+    public void TestMinStringLengthDecode() {
+        Byte[] rawData = Convert.FromBase64String("BgEA");
+        var oid = new Asn1ObjectIdentifier(rawData);
+        Assert.AreEqual("0.0", oid.Value.Value);
+        String encodedB64 = Convert.ToBase64String(oid.GetRawData());
+        Assert.AreEqual("BgEA", encodedB64);
+    }
+    [TestMethod, Description("Test if single arc encoding fails.")]
+    [ExpectedException(typeof(InvalidDataException))]
+    public void TestSingleArcEncodeFail() {
+        new Asn1ObjectIdentifier("0");
+    }
+    [TestMethod, Description("Test if 2nd arc under 'ITU' root node encoded up to 39.")]
+    public void TestItuRootArcConstraintsPass() {
+        new Asn1ObjectIdentifier("1.39");
+    }
+    [TestMethod, Description("Test if 2nd arc under 'ITU' root node >39 fails.")]
+    [ExpectedException(typeof(InvalidDataException))]
+    public void TestItuRootArcConstraintsFail() {
+        new Asn1ObjectIdentifier("1.40");
+    }
+}


### PR DESCRIPTION
addressed #7. Added corresponding unit tests