### PR TITLE
Moved Asn1Parser project back to .NET Standard 2.0

### DIFF
--- a/Asn1Parser/Asn1Parser.csproj
+++ b/Asn1Parser/Asn1Parser.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Version>2.0.0</Version>
     <AssemblyName>SysadminsLV.Asn1Parser</AssemblyName>
@@ -22,8 +22,8 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)'=='Release|net8.0'">
-    <DocumentationFile>bin\Release\net8.0\SysadminsLV.Asn1Parser.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)'=='Release|netstandard2.0'">
+    <DocumentationFile>bin\Release\netstandard2.0\SysadminsLV.Asn1Parser.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)'=='Release|net472'">
     <DocumentationFile>bin\Release\net472\SysadminsLV.Asn1Parser.xml</DocumentationFile>

--- a/nuget/SysadminsLV.Asn1Parser.nuspec
+++ b/nuget/SysadminsLV.Asn1Parser.nuspec
@@ -16,13 +16,13 @@
       <group targetFramework="net472">
         <dependency id="System.Memory" version="4.6.0" />
       </group>
-      <group targetFramework="net8.0">
+      <group targetFramework="netstandard2.0">
         <dependency id="System.Memory" version="4.6.0" />
       </group>
     </dependencies>
   </metadata>
   <files>
     <file src="..\Asn1Parser\bin\Release\net472\SysadminsLV.*" target="lib/net472"/>
-    <file src="..\Asn1Parser\bin\Release\net8.0\SysadminsLV.*" target="lib/net8.0"/>
+    <file src="..\Asn1Parser\bin\Release\netstandard2.0\SysadminsLV.*" target="lib/netstandard2.0"/>
   </files>
 </package>


### PR DESCRIPTION
#### PR Classification
This pull request updates the project's target framework for improved compatibility.
#28 

#### PR Summary
The project transitions from targeting .NET 8.0 to .NET Standard 2.0, updating build and packaging configurations accordingly.
- Asn1Parser.csproj: Replaces net8.0 with netstandard2.0 in <TargetFrameworks>, documentation file paths, and related build properties.
- SysadminsLV.Asn1Parser.nuspec: Updates dependency groups and output file paths to use netstandard2.0 instead of net8.0.
